### PR TITLE
feat: 카드 조회 기능 구현

### DIFF
--- a/http/board.http
+++ b/http/board.http
@@ -1,13 +1,10 @@
 ## Variables
 @boardId = 1
 
-# security 구현 완료 시 헤더에 토큰 추가
-#accessToken: {{accessToken}}
-#refreshToken: {{refreshToken}}
-
 ### 보드 생성
 POST http://localhost:8080/boards
 Content-Type: application/json
+Authorization: {{Authorization}}
 
 {
   "name":"보드 제목",

--- a/http/card.http
+++ b/http/card.http
@@ -1,4 +1,5 @@
 ## Variables
+@boardId = 1
 @columnId = 1
 @cardId = 1
 
@@ -9,6 +10,7 @@
 ### 카드 생성
 POST http://localhost:8080/columns/{{columnId}}/cards
 Content-Type: application/json
+Authorization: {{Authorization}}
 
 {
   "title":"카드 제목",
@@ -20,6 +22,7 @@ Content-Type: application/json
 ### 카드 수정
 PUT http://localhost:8080/columns/{{columnId}}/cards/{{cardId}}
 Content-Type: application/json
+Authorization: {{Authorization}}
 
 {
   "title":"카드 제목 수정",
@@ -30,3 +33,13 @@ Content-Type: application/json
 
 ### 카드 삭제
 DELETE http://localhost:8080/columns/{{columnId}}/cards/{{cardId}}
+Authorization: {{Authorization}}
+
+### 카드 단일 조회
+GET http://localhost:8080/cards/{{cardId}}
+
+### 컬럼 별 카드 목록 조회
+GET http://localhost:8080/columns/{{columnId}}/cards
+
+### 전체 컬럼 카드 목록 조회
+GET http://localhost:8080/board/{{boardId}}/cards/byColumns

--- a/http/column.http
+++ b/http/column.http
@@ -5,7 +5,8 @@
 ### 컬럼 생성
 POST http://localhost:8080/boards/{{boardId}}/columns
 Content-Type: application/json
+Authorization: {{Authorization}}
 
 {
-  "name":"컬럼 이름33"
+  "name":"컬럼 이름1"
 }

--- a/http/comment.http
+++ b/http/comment.http
@@ -1,7 +1,7 @@
 ## Variables
 @cardId = 20
 
-### 카드 생성
+### 댓글 생성
 POST http://localhost:8080/cards/{{cardId}}/comments
 Content-Type: application/json
 

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,0 +1,32 @@
+{
+  "user1": {
+    "email": "user11111@gmail.com",
+    "accountId": "user11111",
+    "password": "password123!@",
+    "name": "user11111"
+  },
+  "user2": {
+    "email": "user22222@gmail.com",
+    "accountId": "user22222",
+    "password": "password123!@",
+    "name": "user22222"
+  },
+  "user3": {
+    "email": "user33333@gmail.com",
+    "accountId": "user33333",
+    "password": "password123!@",
+    "name": "user33333"
+  },
+  "user4": {
+    "email": "user44444@gmail.com",
+    "accountId": "user44444",
+    "password": "password123!@",
+    "name": "user44444"
+  },
+  "user5": {
+    "email": "user55555@gmail.com",
+    "accountId": "user55555",
+    "password": "password123!@",
+    "name": "user55555"
+  }
+}

--- a/http/login.http
+++ b/http/login.http
@@ -3,6 +3,13 @@ POST http://localhost:8080/users/login
 Content-Type: application/json
 
 {
-  "accountId": "test1234",
-  "password": "test1234!!"
+  "accountId": "{{accountId}}",
+  "password": "{{password}}"
 }
+
+> {%
+    client.log(response.headers.valueOf("Authorization"));
+    client.log(response.headers.valueOf("RefreshToken"));
+    client.global.set("Authorization", response.headers.valueOf("Authorization"));
+    client.global.set("RefreshToken", response.headers.valueOf("RefreshToken"));
+%}

--- a/http/signUp.http
+++ b/http/signUp.http
@@ -4,8 +4,8 @@ POST http://localhost:8080/users
 Content-Type: application/json
 
 {
-  "email": "test1234@gmail.com",
-  "accountId": "test1234",
-  "password": "test1234!!",
-  "name": "테스트"
+  "email": "{{email}}",
+  "accountId": "{{accountId}}",
+  "password": "{{password}}",
+  "name": "{{name}}"
 }

--- a/src/main/java/com/sparta/kanbanssam/board/controller/BoardController.java
+++ b/src/main/java/com/sparta/kanbanssam/board/controller/BoardController.java
@@ -4,9 +4,10 @@ package com.sparta.kanbanssam.board.controller;
 import com.sparta.kanbanssam.board.dto.BoardRequestDto;
 import com.sparta.kanbanssam.board.dto.BoardResponseDto;
 import com.sparta.kanbanssam.board.service.BoardService;
-import com.sparta.kanbanssam.user.entity.User;
+import com.sparta.kanbanssam.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,12 +23,10 @@ public class BoardController {
 
     @ResponseBody
     @PostMapping
-    public ResponseEntity<?> createBoard(@RequestBody BoardRequestDto requestDto
-                                      //AuthenticationPrincipal UserDetails userdeatils,
-//                                      BindingResult bindingResult
-                                    ) {
-        User manager = User.builder().id(1L).build(); // User 객체 ID를 일단 1로고정
-        BoardResponseDto responseDto = boardservice.createBoard(requestDto, manager);
+    public ResponseEntity<?> createBoard(
+            @RequestBody BoardRequestDto requestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        BoardResponseDto responseDto = boardservice.createBoard(requestDto, userDetails.getUser());
 
         return ResponseEntity.ok(responseDto);
         }

--- a/src/main/java/com/sparta/kanbanssam/board/entity/Board.java
+++ b/src/main/java/com/sparta/kanbanssam/board/entity/Board.java
@@ -1,10 +1,14 @@
 package com.sparta.kanbanssam.board.entity;
 
+import com.sparta.kanbanssam.card.entity.Card;
+import com.sparta.kanbanssam.column.entity.Columns;
 import com.sparta.kanbanssam.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -21,11 +25,17 @@ public class Board {
     @JoinColumn(name = "manager_id", nullable = false)
     private User manager;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String name;
 
     @Column(nullable = false)
     private String introduction;
+
+    @OneToMany(mappedBy = "board", orphanRemoval = true)
+    private List<Columns> columnsList;
+
+    @OneToMany(mappedBy = "board", orphanRemoval = true)
+    private List<Card> cardList;
 
     @Builder
     public Board(Long id, User manager, String name, String introduction) {

--- a/src/main/java/com/sparta/kanbanssam/board/service/BoardService.java
+++ b/src/main/java/com/sparta/kanbanssam/board/service/BoardService.java
@@ -19,7 +19,7 @@ public class BoardService {
     private final UserRepository userrepository;
 
     @Transactional
-    public  BoardResponseDto createBoard(BoardRequestDto requestDto, User manager /* 대신 userdetails*/) {
+    public  BoardResponseDto createBoard(BoardRequestDto requestDto, User manager) {
 //        user = userrepository.findById().orElseThrow(()
 //                -> new CustomException(ErrorType.USER_NOT_FOUND));
 //        if(userRole.enum)

--- a/src/main/java/com/sparta/kanbanssam/card/controller/CardController.java
+++ b/src/main/java/com/sparta/kanbanssam/card/controller/CardController.java
@@ -1,17 +1,22 @@
 package com.sparta.kanbanssam.card.controller;
 
+import com.sparta.kanbanssam.card.dto.CardListByColumnsResponseDto;
 import com.sparta.kanbanssam.card.dto.CardRequestDto;
 import com.sparta.kanbanssam.card.dto.CardResponseDto;
 import com.sparta.kanbanssam.card.service.CardService;
+import com.sparta.kanbanssam.security.UserDetailsImpl;
 import com.sparta.kanbanssam.user.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Controller
-@RequestMapping("/columns")
+@RequestMapping
 @RequiredArgsConstructor
 public class CardController {
 
@@ -24,13 +29,12 @@ public class CardController {
      * @return 카드 정보
      */
     @ResponseBody
-    @PostMapping("/{columnId}/cards")
+    @PostMapping("/columns/{columnId}/cards")
     public ResponseEntity<?> createCard(
             @PathVariable Long columnId,
-            @Valid @RequestBody CardRequestDto requestDto) {
-        // todo : secutity 구현 완료 시 userDetails 로 수정
-        User user = User.builder().id(1L).build();
-        CardResponseDto responseDto = cardService.createCard(columnId, requestDto, user);
+            @Valid @RequestBody CardRequestDto requestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        CardResponseDto responseDto = cardService.createCard(columnId, requestDto, userDetails.getUser());
         return ResponseEntity.ok(responseDto);
     }
 
@@ -42,14 +46,13 @@ public class CardController {
      * @return 카드 정보
      */
     @ResponseBody
-    @PutMapping("/{columnId}/cards/{cardId}")
+    @PutMapping("/columns/{columnId}/cards/{cardId}")
     public ResponseEntity<?> updateCard(
             @PathVariable Long columnId,
             @PathVariable Long cardId,
-            @Valid @RequestBody CardRequestDto requestDto) {
-        // todo : secutity 구현 완료 시 userDetails 로 수정
-        User user = User.builder().id(1L).build();
-        CardResponseDto responseDto = cardService.updateCard(cardId, requestDto, user);
+            @Valid @RequestBody CardRequestDto requestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        CardResponseDto responseDto = cardService.updateCard(cardId, requestDto, userDetails.getUser());
         return ResponseEntity.ok(responseDto);
     }
 
@@ -59,20 +62,81 @@ public class CardController {
      * @param cardId 카드 ID
      */
     @ResponseBody
-    @DeleteMapping("/{columnId}/cards/{cardId}")
+    @DeleteMapping("/columns/{columnId}/cards/{cardId}")
     public void deleteCard(
             @PathVariable Long columnId,
-            @PathVariable Long cardId) {
-        // todo : secutity 구현 완료 시 userDetails 로 수정
-        User user = User.builder().id(1L).build();
-        cardService.deleteCard(cardId, user);
+            @PathVariable Long cardId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        cardService.deleteCard(cardId, userDetails.getUser());
     }
+
+    /**
+     * 카드 단일 조회
+     * @param cardId 카드 ID
+     * @return 카드 정보
+     */
+    @ResponseBody
+    @GetMapping("/cards/{cardId}")
+    public ResponseEntity<?> getCard(
+            @PathVariable Long cardId) {
+        CardResponseDto responseDto = cardService.getCard(cardId);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    /**
+     * 보드 별 카드 전체 목록 조회
+     * @param boardId 보드 ID
+     * @return 카드 목록
+     */
+    @ResponseBody
+    @GetMapping("/board/{boardId}/cards")
+    public ResponseEntity<?> getCardListByBoard(
+            @PathVariable Long boardId) {
+        List<CardResponseDto> responseDtos = cardService.getCardListByBoard(boardId);
+        return ResponseEntity.ok(responseDtos);
+    }
+
+    /**
+     * 단일 컬럼 카드 목록 조회
+     * @param columnId 컬럼 ID
+     * @return 카드 목록
+     */
+    @ResponseBody
+    @GetMapping("/columns/{columnId}/cards")
+    public ResponseEntity<?> getCardByColumn(
+            @PathVariable Long columnId) {
+        List<CardResponseDto> cardList = cardService.getCardList(columnId);
+        return ResponseEntity.ok(cardList);
+    }
+
+    /**
+     * 전체 컬럼 별 카드 목록 조회
+     * @param boardId 보드 ID
+     * @return 컬럼 별 카드 목록
+     */
+    @ResponseBody
+    @GetMapping("/board/{boardId}/cards/byColumns")
+    public ResponseEntity<?> getCardListByColumn(
+            @PathVariable Long boardId) {
+        List<CardListByColumnsResponseDto> responseDto = cardService.getCardListByColumn(boardId);
+        return ResponseEntity.ok(responseDto);
+    }
+
+//    @ResponseBody
+//    @GetMapping("/board/{boardId}/cards/byUser")
+//    public ResponseEntity<?> getCardListByUser(@PathVariable Long boardId) {
+//
+//    }
+
+    /**
+     * --------------------------------------------------------------
+     */
 
     /**
      * test용 view
      * @return card.html
      */
-    @GetMapping("/cards/view")
+    @GetMapping("/columns/cards/view")
     public String cardView() {
         return "/card/card";
     }

--- a/src/main/java/com/sparta/kanbanssam/card/dto/CardListByColumnsResponseDto.java
+++ b/src/main/java/com/sparta/kanbanssam/card/dto/CardListByColumnsResponseDto.java
@@ -1,0 +1,25 @@
+package com.sparta.kanbanssam.card.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CardListByColumnsResponseDto {
+
+    private Long columnId;
+    private String columnName;
+    private Long columnOrder;
+    private List<CardResponseDto> cardList;
+
+    @Builder
+    public CardListByColumnsResponseDto(Long columnId, String columnName, Long columnOrder, List<CardResponseDto> cardList) {
+        this.columnId = columnId;
+        this.columnName = columnName;
+        this.columnOrder = columnOrder;
+        this.cardList = cardList;
+    }
+}

--- a/src/main/java/com/sparta/kanbanssam/card/entity/Card.java
+++ b/src/main/java/com/sparta/kanbanssam/card/entity/Card.java
@@ -1,5 +1,6 @@
 package com.sparta.kanbanssam.card.entity;
 
+import com.sparta.kanbanssam.board.entity.Board;
 import com.sparta.kanbanssam.card.dto.CardRequestDto;
 import com.sparta.kanbanssam.column.entity.Columns;
 import com.sparta.kanbanssam.comment.entity.Comment;
@@ -31,6 +32,10 @@ public class Card extends Timestamped {
     private User user;
 
     @ManyToOne
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    @ManyToOne
     @JoinColumn(name = "column_id", nullable = false)
     private Columns columns;
 
@@ -53,9 +58,10 @@ public class Card extends Timestamped {
     private List<Comment> commentList;
 
     @Builder
-    public Card(Long id, User user, Columns columns, String title, String content, String responsiblePerson, LocalDateTime deadline, Long orders) {
+    public Card(Long id, User user, Board board, Columns columns, String title, String content, String responsiblePerson, LocalDateTime deadline, Long orders) {
         this.id = id;
         this.user = user;
+        this.board = board;
         this.columns = columns;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/sparta/kanbanssam/card/repository/CardRepository.java
+++ b/src/main/java/com/sparta/kanbanssam/card/repository/CardRepository.java
@@ -1,8 +1,14 @@
 package com.sparta.kanbanssam.card.repository;
 
+import com.sparta.kanbanssam.card.dto.CardRequestDto;
 import com.sparta.kanbanssam.card.entity.Card;
+import com.sparta.kanbanssam.column.entity.Columns;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface CardRepository extends JpaRepository<Card, Long> {
     Long countAllByColumnsId(Long columnId);
+
+    List<Card> findAllByColumnsOrderByOrders(Columns columns);
 }

--- a/src/main/java/com/sparta/kanbanssam/column/controller/ColumnController.java
+++ b/src/main/java/com/sparta/kanbanssam/column/controller/ColumnController.java
@@ -1,14 +1,12 @@
 package com.sparta.kanbanssam.column.controller;
 
-import com.sparta.kanbanssam.board.entity.Board;
-import com.sparta.kanbanssam.card.dto.CardRequestDto;
-import com.sparta.kanbanssam.card.dto.CardResponseDto;
 import com.sparta.kanbanssam.column.dto.ColumnRequestDto;
 import com.sparta.kanbanssam.column.dto.ColumnResponseDto;
 import com.sparta.kanbanssam.column.service.ColumnService;
-import com.sparta.kanbanssam.user.entity.User;
+import com.sparta.kanbanssam.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,10 +18,11 @@ public class ColumnController {
 
     @ResponseBody
     @PostMapping("/{boardId}/columns")
-    public ResponseEntity<?> createColumn(@PathVariable Long boardId, @RequestBody ColumnRequestDto requestDto){
-        // todo : secutity 구현 완료 시 userDetails 로 수정
-        User user = User.builder().id(1L).build();
-        ColumnResponseDto responseDto = columnService.createColum(boardId, requestDto, user);
+    public ResponseEntity<?> createColumn(
+            @PathVariable Long boardId,
+            @RequestBody ColumnRequestDto requestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails){
+        ColumnResponseDto responseDto = columnService.createColum(boardId, requestDto, userDetails.getUser());
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/com/sparta/kanbanssam/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/kanbanssam/comment/controller/CommentController.java
@@ -4,9 +4,11 @@ package com.sparta.kanbanssam.comment.controller;
 import com.sparta.kanbanssam.comment.dto.CommentCreatedResponseDto;
 import com.sparta.kanbanssam.comment.dto.CommentRequestDto;
 import com.sparta.kanbanssam.comment.service.CommentService;
+import com.sparta.kanbanssam.security.UserDetailsImpl;
 import com.sparta.kanbanssam.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,10 +24,11 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping("/cards/{cardId}/comments")
-    public ResponseEntity<?> addComment(@PathVariable("cardId") Long cardId, @RequestBody CommentRequestDto requestDto) {
-        // todo : secutity 구현 완료 시 userDetails 로 수정
-        User user = User.builder().id(1L).build();
-        CommentCreatedResponseDto responseDto = commentService.createComment(cardId, requestDto, user);
+    public ResponseEntity<?> addComment(
+            @PathVariable("cardId") Long cardId,
+            @RequestBody CommentRequestDto requestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        CommentCreatedResponseDto responseDto = commentService.createComment(cardId, requestDto, userDetails.getUser());
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/com/sparta/kanbanssam/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/kanbanssam/config/WebSecurityConfig.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -70,7 +71,11 @@ public class WebSecurityConfig {
                 authorizeHttpRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
                         .requestMatchers("/users").permitAll()
-                        .requestMatchers("/users/login").permitAll() //
+                        .requestMatchers("/users/login").permitAll()
+                        .requestMatchers("/users/view/signup").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/cards/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/columns/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/board/**").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );
 
@@ -79,10 +84,6 @@ public class WebSecurityConfig {
                         .loginPage("/users/view/login-page").permitAll()
         );
 
-        http.formLogin((formLogin) ->
-                formLogin
-                        .loginPage("/users/view/signup").permitAll()
-        );
 
         // 필터 순서 설정 : 인가 필터 > 인증 필터 > Username ~ 필터
         http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);


### PR DESCRIPTION
1. 단일 카드 조회
2. 보드 별 전체 카드 목록 조회
3. 단일 컬럼 카드 목록 조회
3. 전체 컬럼 별 카드 목록 조회
4. Board 엔티티 columnList, cardList 양방향 관계 추가
5. 카드 조회 API 호출 HTTP Client 추가
6. 로그인/회원가입 코드 병합
 - 각 도메인 컨트롤러 인증 객체 파라미터 추가
 - SecutiryConfig requestMatchers 추가

resolves:#16