### PR TITLE
feat: 컬럼 삭제 기능

### DIFF
--- a/http/column.http
+++ b/http/column.http
@@ -1,6 +1,6 @@
 ### Variables
 @boardId = 1
-@columnId =1
+@columnId =3
 
 
 ### 컬럼 생성
@@ -9,7 +9,7 @@ Content-Type: application/json
 Authorization: {{Authorization}}
 
 {
-  "name":"컬럼 이름1"
+  "name":"컬럼 이름3"
 }
 
 
@@ -17,7 +17,14 @@ Authorization: {{Authorization}}
 ### 컬럼 수정
 PUT http://localhost:8080/boards/{{boardId}}/columns/{{columnId}}
 Content-Type: application/json
+Authorization: {{Authorization}}
 
 {
-  "name":"컬럼 이름33444"
+  "name":"컬럼 이름3를 수정해보자"
 }
+
+### 컬럼 삭제
+DELETE http://localhost:8080/boards/{{boardId}}/columns/{{columnId}}
+Content-Type: application/json
+Authorization: {{Authorization}}
+

--- a/src/main/java/com/sparta/kanbanssam/column/controller/ColumnController.java
+++ b/src/main/java/com/sparta/kanbanssam/column/controller/ColumnController.java
@@ -54,7 +54,7 @@ public class ColumnController {
      */
     @ResponseBody
     @PutMapping("/{boardId}/columns/{columnId}")
-    public ResponseEntity<?> updateCard(
+    public ResponseEntity<?> updateColumn(
             @PathVariable Long boardId,
             @PathVariable Long columnId,
             @Valid @RequestBody ColumnRequestDto requestDto,
@@ -66,6 +66,21 @@ public class ColumnController {
         // 권한 확인 후 컬럼 생성
         ColumnResponseDto responseDto = columnService.updateColumn(columnId, requestDto, user);
         return ResponseEntity.ok(responseDto);
+    }
+
+    @ResponseBody
+    @DeleteMapping("/{boardId}/columns/{columnId}")
+    public void deleteColumn(
+            @PathVariable Long boardId,
+            @PathVariable Long columnId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails){
+
+        // 로그인된 사용자 정보 가져오기
+        User user = userDetails.getUser();
+
+        // 권한 확인 후 컬럼 생성
+        columnService.deleteColumn(columnId, user);
+
     }
 
     @GetMapping("/columns/view")

--- a/src/main/java/com/sparta/kanbanssam/column/entity/Columns.java
+++ b/src/main/java/com/sparta/kanbanssam/column/entity/Columns.java
@@ -32,7 +32,7 @@ public class Columns {
     @Column(nullable = false)
     private Long orders;
 
-    @OneToMany(mappedBy = "columns", orphanRemoval = true)
+    @OneToMany(mappedBy = "columns",cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Card> cardList;
 
     @Builder

--- a/src/main/java/com/sparta/kanbanssam/column/service/ColumnService.java
+++ b/src/main/java/com/sparta/kanbanssam/column/service/ColumnService.java
@@ -80,6 +80,20 @@ public class ColumnService {
     }
 
     /**
+     * 컬럼 삭제
+     * @param columnId 컬럼 ID
+     * @param user 회원 정보
+     */
+    @Transactional
+    public void deleteColumn(Long columnId, User user) {
+        Columns column = getColumn(columnId);
+
+        // 컬럼 작성자가 아닐 경우 예외처리(보드 매니저가 아닐경우)
+        authorizationService.validateUserIsBoardManager(column.getBoard().getId(), user);
+        columnRepository.delete(column);
+    }
+
+    /**
      * Id로 Columns 엔티티 찾기
      * @param columnId 컬럼 ID
      * @return 컬럼 정보


### PR DESCRIPTION
1. 컬럼 삭제 기능 추가.
2. 컬럼 삭제시 컬럼이 소속된 보드를 생성한 매니저인지 확인하는 로직 추가.
3. 컬럼을 삭제하면 해당 컬럼에 소속된 카드도 삭제되도록 컬럼엔티티의 카드리스트에 cascade = CascadeType.ALL을 추가.

resolves: #31